### PR TITLE
fallback sync only when mqtt disconnected

### DIFF
--- a/src/MqttAdapter.js
+++ b/src/MqttAdapter.js
@@ -24,6 +24,9 @@ export default class MqttAdapter {
         callbacks.delivered(topic[3], message);
       }
     })
+    this.mqtt.on('offline', function() {
+      QiscusSDK.core.activateSync();
+    })
   }
   subscribe(topic) {
     this.mqtt.subscribe(topic);

--- a/src/sdk/index.js
+++ b/src/sdk/index.js
@@ -43,7 +43,7 @@ export class qiscusSDK extends EventEmitter {
     self.isLogin     = false
     self.isLoading   = false
     self.isInit      = false
-    self.sync        = 'both' // possible values 'socket', 'http', 'both'
+    self.sync        = 'socket' // possible values 'socket', 'http', 'both'
     // there's two mode, widget and wide
     self.mode        = 'widget'
     self.plugins     = []


### PR DESCRIPTION
basically this PR is small changes to make the sync only happen when mqtt websocket connection failed. this will may reduce the number of unnecessary sync when we have good mqtt connection established.