### PR TITLE
fix very long comment preview issue

### DIFF
--- a/src/vue/assets/scss/_comment.scss
+++ b/src/vue/assets/scss/_comment.scss
@@ -144,7 +144,7 @@
 .qcw-image-container {
   height: 100px; overflow: hidden;
   border-radius: 0 0 5px 5px;
-  
+
   img {
     min-width: 200px;
     min-height: 110px;
@@ -280,6 +280,9 @@ code {
   font-size: 12px;
   text-align: left;
   color: #757575;
+  max-height: 150px;
+  overflow-y: scroll;
+  scroll-behavior: smooth;
   margin-bottom: 10px;
   .reply-preview & {
     margin-bottom: 0;
@@ -304,7 +307,10 @@ code {
   position: absolute;
   bottom: 40px;
   width: 100%;
+  max-height: 50%;
   line-height: 1.7em;
+  overflow-y: scroll;
+  scroll-behavior: smooth;
   z-index: 2;
 }
 .reply-preview__close-btn {

--- a/src/vue/components/ChatWindow.vue
+++ b/src/vue/components/ChatWindow.vue
@@ -28,7 +28,7 @@
           <div v-if="!selected.custom_title">{{ selected.name }}</div>
           <div v-if="selected.custom_title">{{ selected.custom_title }}</div>
           <div v-if="mqttData.typing != ''" class="isTypingText">{{ mqttData.typing }} is typing ...</div>
-          <div v-if="!mqttData.typing && chatmateStatus" class="isTypingText">{{ chatmateStatus }}</div>
+          <div v-if="!mqttData.typing && chatmateStatus && selected.room_type != 'group'" class="isTypingText">{{ chatmateStatus }}</div>
           <div v-if="selected.custom_subtitle && !mqttData.typing" class="isTypingText">{{ selected.custom_subtitle }}</div>
         </div>
         <i class="fa fa-chevron-down" @click="toggleChatWindow"></i>


### PR DESCRIPTION
fix very long comment preview issue. 

we have trouble when the comment text is very long, then the comment preview on reply action will rendering uncontrolled container height, that will hide the close button of comment preview.

file change:
src/vue/assets/scss/_comment.scss


TLDR;
I found the develop branch not up to date, refer to the master branch, so here we go! I bring 4 other commits from master branch 